### PR TITLE
Resolve encoding issues on GUI mode

### DIFF
--- a/NiimPrintX/ui/component/FontList.py
+++ b/NiimPrintX/ui/component/FontList.py
@@ -27,7 +27,7 @@ def fonts():
     # magick_path = 'imagemagick/bin/magick'
 
     # Path to the local ImageMagick binary within the collected data
-    result = subprocess.run([magick_path, '-list', 'font'], stdout=subprocess.PIPE, text=True)
+    result = subprocess.run([magick_path, '-list', 'font'], stdout=subprocess.PIPE, text=True, encoding='utf8')
     output = result.stdout
     fonts_details = parse_font_details(output)
     grouped_fonts = group_fonts_by_family(fonts_details)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pyobjc-framework-Cocoa==9.2
 pyobjc-framework-CoreBluetooth==9.2
 pyobjc-framework-libdispatch==9.2
 rich==13.7.1
-setuptools==69.5.1
+setuptools==70.0.0
 six==1.16.0
 Wand==0.6.13
-wheel==0.37.1
+wheel==0.38.1


### PR DESCRIPTION
It was found during resolving #26 that the GUI mode gets unable to run if the system has a font with non-ASCII characters on its name.

Specifying an encoding of `'utf8'` to `subprocess.run` finding fonts in the system solved this problem.