### PR TITLE
Changing the Device in the UI doesn't change the device in the background

### DIFF
--- a/NiimPrintX/ui/widget/CanvasSelector.py
+++ b/NiimPrintX/ui/widget/CanvasSelector.py
@@ -39,6 +39,7 @@ class CanvasSelector:
         device = self.selected_device.get().lower()
         if device:
             label_sizes = list(self.config.label_sizes[device]['size'].keys())
+            self.config.device = device
         else:
             label_sizes = []
         self.label_size_option['values'] = label_sizes


### PR DESCRIPTION
Currently, when changing devices in the UI, the device isn't actually changed everywhere in the code. Even after changing the device, I see an error that I am not able to connect to D110, even though I have chosen a different device. This small change fixes the issue