### PR TITLE
D110 connection issue

### DIFF
--- a/NiimPrintX/nimmy/bluetooth.py
+++ b/NiimPrintX/nimmy/bluetooth.py
@@ -10,7 +10,7 @@ logger = get_logger()
 async def find_device(device_name_prefix=None):
     devices = await BleakScanner.discover()
     for device in devices:
-        if device.name and device.name.lower().startswith(device_name_prefix.lower()):
+        if device.name and device.name.lower().startswith(device_name_prefix.lower())  and len(device.metadata['uuids'])==0:
             return device
     raise BLEException(f"Failed to find device {device_name_prefix}")
 


### PR DESCRIPTION
D110 shows as two Bluetooth devices. One has a number of services, the other has none. On the D110 we want the one with no services

In the longer term the user should be able to choose the device in the UI or we should find a better heuristic. Perhaps we could look for a particular device type?