### PR TITLE
Add B21S support, B1 protocol, and GUI label preview tools

### DIFF
--- a/NiimPrintX/cli/command.py
+++ b/NiimPrintX/cli/command.py
@@ -5,6 +5,7 @@ from NiimPrintX.nimmy.bluetooth import find_device
 from NiimPrintX.nimmy.printer import PrinterClient, InfoEnum
 from NiimPrintX.nimmy.logger_config import setup_logger, get_logger, logger_enable
 from NiimPrintX.nimmy.helper import print_info, print_error, print_success
+from NiimPrintX.nimmy.models import CLI_MODELS, PRINTHEAD_WIDTH
 
 from devtools import debug
 
@@ -32,7 +33,7 @@ def niimbot_cli(ctx, verbose):
 @click.option(
     "-m",
     "--model",
-    type=click.Choice(["b1", "b18", "b21", "d11", "d11_h", "d110"], False),
+    type=click.Choice(list(CLI_MODELS), False),
     default="d110",
     show_default=True,
     help="Niimbot printer model",
@@ -84,12 +85,9 @@ def niimbot_cli(ctx, verbose):
 def print_command(model, density, rotate, image, quantity, vertical_offset, horizontal_offset):
     logger.info(f"Niimbot Printing Start")
 
-    if model in ("b1", "b18", "b21"):
-        max_width_px = 384
-    if model in ("d11", "d11_h", "d110"):
-        max_width_px = 240
+    max_width_px = PRINTHEAD_WIDTH.get(model, 384)
 
-    if model in ("b18", "d11", "d11_h", "d110") and density > 3:
+    if model in ("b18", "d11", "d110") and density > 3:
         density = 3
     try:
         image = Image.open(image)
@@ -110,8 +108,14 @@ async def _print(model, density, image, quantity, vertical_offset, horizontal_of
         printer = PrinterClient(device)
         if await printer.connect():
             print(f"Connected to {device.name}")
-        await printer.print_image(image, density=density, quantity=quantity, vertical_offset=vertical_offset,
-                                  horizontal_offset=horizontal_offset)
+        await printer.print_for_model(
+            model,
+            image,
+            density=density,
+            quantity=quantity,
+            vertical_offset=vertical_offset,
+            horizontal_offset=horizontal_offset,
+        )
         print_success("Print job completed")
         await printer.disconnect()
     except Exception as e:
@@ -123,7 +127,7 @@ async def _print(model, density, image, quantity, vertical_offset, horizontal_of
 @click.option(
     "-m",
     "--model",
-    type=click.Choice(["b1", "b18", "b21", "d11", "d11_h", "d110"], False),
+    type=click.Choice(list(CLI_MODELS), False),
     default="d110",
     show_default=True,
     help="Niimbot printer model",

--- a/NiimPrintX/nimmy/bluetooth.py
+++ b/NiimPrintX/nimmy/bluetooth.py
@@ -3,15 +3,28 @@ from bleak import BleakClient, BleakScanner
 
 from .exception import BLEException
 from .logger_config import get_logger
+from .models import matches_model
 
 logger = get_logger()
 
 
 async def find_device(device_name_prefix=None):
-    devices = await BleakScanner.discover()
-    for device in devices:
-        if device.name and device.name.lower().startswith(device_name_prefix.lower())  and len(device.metadata['uuids'])==0:
+    # Bleak 1.x removed BLEDevice.metadata; use advertisement data instead.
+    # Prefer the advertising address with no service UUIDs (Niimbot dual-address quirk),
+    # but fall back to devices that advertise services (required for B21S).
+    discovered = await BleakScanner.discover(return_adv=True)
+    model = (device_name_prefix or "").lower()
+    fallback = None
+    for device, adv in discovered.values():
+        if not matches_model(device.name, model):
+            continue
+        service_uuids = list(getattr(adv, "service_uuids", None) or [])
+        if len(service_uuids) == 0:
             return device
+        if fallback is None:
+            fallback = device
+    if fallback is not None:
+        return fallback
     raise BLEException(f"Failed to find device {device_name_prefix}")
 
 
@@ -20,7 +33,7 @@ async def scan_devices(device_name=None):
     devices = await BleakScanner.discover()
     for device in devices:
         if device_name:
-            if device.name and device_name.lower() in device.name.lower():
+            if device.name and matches_model(device.name, device_name):
                 print(f"Found device: {device.name} at {device.address}")
                 return device
         else:
@@ -34,14 +47,14 @@ class BLETransport:
         self.client = None
 
     async def __aenter__(self):
-        # Automatically connect if address is provided during initialization
         if self.address:
             self.client = BleakClient(self.address)
-            if await self.client.connect():
+            await self.client.connect()
+            if self.client.is_connected:
+                await self._ensure_mtu()
                 logger.info(f"Connected to {self.address}")
                 return self
-            else:
-                raise BLEException(f"Failed to connect to the BLE device at {self.address}")
+            raise BLEException(f"Failed to connect to the BLE device at {self.address}")
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
@@ -50,21 +63,57 @@ class BLETransport:
             logger.info("Disconnected.")
 
     async def connect(self, address):
+        # Bleak 1.x connect() returns None; use is_connected for success.
         if self.client is None:
             self.client = BleakClient(address)
         if not self.client.is_connected:
-            return await self.client.connect()
-        return False
+            await self.client.connect()
+            await self._ensure_mtu()
+        return self.client.is_connected
+
+    async def _ensure_mtu(self):
+        """Raise ATT MTU so write-with-response can carry full bitmap rows (~61 bytes)."""
+        if not self.client:
+            return
+        backend = getattr(self.client, "_backend", None)
+        if backend is not None and hasattr(backend, "_acquire_mtu"):
+            try:
+                await backend._acquire_mtu()
+                logger.info(f"BLE MTU negotiated: {getattr(self.client, 'mtu_size', '?')}")
+            except Exception as e:
+                logger.warning(f"BLE MTU negotiate failed: {e}")
 
     async def disconnect(self):
         if self.client and self.client.is_connected:
             await self.client.disconnect()
 
     async def write(self, data, char_uuid):
-        if self.client and self.client.is_connected:
-            await self.client.write_gatt_char(char_uuid, data)
-        else:
+        if not (self.client and self.client.is_connected):
             raise BLEException("BLE client is not connected.")
+
+        # BlueZ often keeps max_write_without_response_size at 20 even after MTU
+        # negotiation. PrintBitmapRow packets are ~61 bytes, so we must use
+        # write-with-response (uses negotiated MTU) for large payloads. Truncated
+        # write-without-response packets produce blank labels on B21S.
+        char = None
+        try:
+            char = self.client.services.get_characteristic(char_uuid)
+        except Exception:
+            pass
+
+        max_wo = 20
+        if char is not None:
+            max_wo = getattr(char, "max_write_without_response_size", 20) or 20
+
+        props = set(getattr(char, "properties", None) or [])
+        if len(data) <= max_wo and "write-without-response" in props:
+            use_response = False
+        elif "write" in props:
+            use_response = True
+        else:
+            use_response = False
+
+        await self.client.write_gatt_char(char_uuid, data, response=use_response)
 
     async def start_notification(self, char_uuid, handler):
         if self.client and self.client.is_connected:

--- a/NiimPrintX/nimmy/models.py
+++ b/NiimPrintX/nimmy/models.py
@@ -1,0 +1,59 @@
+"""Shared printer model metadata for CLI and UI."""
+
+# Models that use B1-style 7-byte PrintStart + 6-byte SetPageSize (niimbluelib B1 task).
+B1_PROTOCOL_MODELS = frozenset({"b1", "b21_c2b"})
+
+# Models that need 6-byte SetPageSize (rows, cols, copies). B21S prints blank with 4-byte.
+PAGE_SIZE_6B_MODELS = frozenset({"b21s", "b21s_c2b", "b21", "d101", "b1", "b21_c2b"})
+
+# BLE advertisement name matching: longer / more specific keys first.
+MODEL_NAME_MATCHERS = {
+    "b21s": lambda n: n.startswith("b21s"),
+    # Accept classic B21 and B21S when user selects b21 (same printhead family).
+    "b21": lambda n: n.startswith("b21"),
+    "b18": lambda n: n.startswith("b18"),
+    "b1": lambda n: n.startswith("b1") and not n.startswith(("b18", "b21")),
+    "d11_h": lambda n: n.startswith("d11") or "d11" in n,
+    "d110": lambda n: n.startswith("d110") or n.startswith("d11"),
+    "d11": lambda n: n.startswith("d11"),
+    "d101": lambda n: n.startswith("d101"),
+}
+
+CLI_MODELS = ("b1", "b18", "b21", "b21s", "d11", "d11_h", "d110", "d101")
+
+PRINTHEAD_WIDTH = {
+    "b1": 384,
+    "b18": 384,
+    "b21": 384,
+    "b21s": 384,
+    "d11": 240,
+    "d11_h": 240,
+    "d110": 240,
+    "d101": 240,
+}
+
+
+def matches_model(device_name: str, model: str) -> bool:
+    if not device_name:
+        return False
+    name = device_name.lower().strip()
+    model = (model or "").lower()
+    matcher = MODEL_NAME_MATCHERS.get(model)
+    if matcher:
+        return matcher(name)
+    # Fallback: prefix match, but avoid b1 matching b21
+    if model == "b1":
+        return name.startswith("b1") and not name.startswith(("b18", "b21"))
+    if model == "b21":
+        # Prefer exact B21, but also accept B21S so users can print with -m b21
+        return name.startswith("b21")
+    return name.startswith(model)
+
+
+def uses_b1_protocol(model: str) -> bool:
+    return (model or "").lower() in B1_PROTOCOL_MODELS
+
+
+def uses_page_size_6b(model: str) -> bool:
+    """B21S (and several others) require SetPageSize with copies count or print blank."""
+    return (model or "").lower() in PAGE_SIZE_6B_MODELS

--- a/NiimPrintX/nimmy/packet.py
+++ b/NiimPrintX/nimmy/packet.py
@@ -1,17 +1,19 @@
-from devtools import debug
-
-
 def packet_to_int(x):
     return int.from_bytes(x.data, "big")
 
 
 class NiimbotPacket:
+    CONNECT = 0xC1
+
     def __init__(self, type_, data):
         self.type = type_
         self.data = data
 
     @classmethod
     def from_bytes(cls, pkt):
+        # Connect frames may include a leading 0x03 prefix
+        if pkt and pkt[0] == 0x03:
+            pkt = pkt[1:]
         assert pkt[:2] == b"\x55\x55"
         assert pkt[-2:] == b"\xaa\xaa"
         type_ = pkt[2]
@@ -29,9 +31,13 @@ class NiimbotPacket:
         checksum = self.type ^ len(self.data)
         for i in self.data:
             checksum ^= i
-        return bytes(
+        frame = bytes(
             (0x55, 0x55, self.type, len(self.data), *self.data, checksum, 0xAA, 0xAA)
         )
+        # Official app / niimbluelib prefix Connect with 0x03
+        if self.type == self.CONNECT:
+            return bytes((0x03,)) + frame
+        return frame
 
     def __repr__(self):
         return f"<NiimbotPacket type={self.type} data={self.data}>"

--- a/NiimPrintX/nimmy/printer.py
+++ b/NiimPrintX/nimmy/printer.py
@@ -40,6 +40,7 @@ class RequestCodeEnum(enum.IntEnum):
     SET_DIMENSION = 19  # 0x13
     SET_QUANTITY = 21  # 0x15
     GET_PRINT_STATUS = 163  # 0xA3
+    CONNECT = 0xC1
 
 
 class PrinterClient:
@@ -51,7 +52,8 @@ class PrinterClient:
         self.notification_data = None
 
     async def connect(self):
-        if await self.transport.connect(self.device.address):
+        # Pass BLEDevice (not just address) for more reliable BlueZ connections.
+        if await self.transport.connect(self.device):
             if not self.char_uuid:
                 await self.find_characteristics()
             logger.info(f"Successfully connected to {self.device.name}")
@@ -84,23 +86,33 @@ class PrinterClient:
         if not self.char_uuid:
             raise PrinterException("Cannot find bluetooth characteristics.")
 
-    async def send_command(self, request_code, data, timeout=10):
+    async def send_command(self, request_code, data, timeout=5):
+        if not self.transport.client or not self.transport.client.is_connected:
+            await self.connect()
+        packet = NiimbotPacket(request_code, data)
+        self.notification_event.clear()
+        self.notification_data = None
         try:
-            if not self.transport.client or not self.transport.client.is_connected:
-                await self.connect()
-            packet = NiimbotPacket(request_code, data)
             await self.transport.start_notification(self.char_uuid, self.notification_handler)
             await self.transport.write(packet.to_bytes(), self.char_uuid)
             logger.debug(f"Printer command sent - {RequestCodeEnum(request_code).name}")
-            await asyncio.wait_for(self.notification_event.wait(), timeout)  # Wait until the notification event is set
-            response = NiimbotPacket.from_bytes(self.notification_data)
-            await self.transport.stop_notification(self.char_uuid)
-            self.notification_event.clear()  # Reset the event for the next notification
-            return response
+            await asyncio.wait_for(self.notification_event.wait(), timeout)
+            if not self.notification_data:
+                return None
+            return NiimbotPacket.from_bytes(self.notification_data)
         except asyncio.TimeoutError:
             logger.error(f"Timeout occurred for request {RequestCodeEnum(request_code).name}")
+            return None
         except BLEException as e:
             logger.error(f"An error occurred: {e}")
+            return None
+        finally:
+            # Always stop notify — leaving it on breaks bulk bitmap writes / hangs finish.
+            try:
+                await self.transport.stop_notification(self.char_uuid)
+            except Exception:
+                pass
+            self.notification_event.clear()
 
     async def write_raw(self, data):
         try:
@@ -120,58 +132,179 @@ class PrinterClient:
             logger.error(f"An error occurred: {e}")
 
     def notification_handler(self, sender, data):
-        # print(f"Notification from {sender}: {data}")
         logger.trace(f"Notification: {data}")
         self.notification_data = data
         self.notification_event.set()
 
     async def print_image(self, image: Image, density: int = 3, quantity: int = 1, vertical_offset= 0,
-                          horizontal_offset = 0):
+                          horizontal_offset = 0, *, invert: bool = True, use_print_clear: bool = False,
+                          page_size_6b: bool = False):
+        """Print path for D110 / B21 / B21S family.
+
+        B21S requires 6-byte SetPageSize (rows, cols, copies). Using 4-byte page size
+        makes the printer feed a blank label (AndBondStyle/niimprint#33).
+        """
+        try:
+            await self.handshake_connect()
+        except Exception as e:
+            logger.debug(f"Connect handshake skipped: {e}")
+
         await self.set_label_density(density)
         await self.set_label_type(1)
         await self.start_print()
+        if use_print_clear:
+            try:
+                await self.allow_print_clear()
+            except Exception as e:
+                logger.debug(f"Print clear skipped: {e}")
         await self.start_page_print()
-        await self.set_dimension(image.height, image.width)
-        await self.set_quantity(quantity)
+
+        # Critical for B21S: 6-byte dimension includes quantity/copies
+        if page_size_6b:
+            await self.set_dimension_v2(image.height, image.width, quantity)
+        else:
+            await self.set_dimension(image.height, image.width)
+            await self.set_quantity(quantity)
+
+        try:
+            await self.transport.stop_notification(self.char_uuid)
+        except Exception:
+            pass
+
+        row_count = 0
+        for pkt in self._encode_image(image, vertical_offset, horizontal_offset, invert=invert):
+            await self.write_raw(pkt)
+            row_count += 1
+            await asyncio.sleep(0.01)
+        logger.info(f"Sent {row_count} bitmap rows (invert={invert}, page_size_6b={page_size_6b})")
+
+        # Allow paper advance before polling
+        await asyncio.sleep(0.5)
+
+        ok = False
+        for _ in range(10):
+            packet = await self.send_command(RequestCodeEnum.END_PAGE_PRINT, b"\x01", timeout=2)
+            if packet and packet.data and packet.data[0]:
+                ok = True
+                break
+            await asyncio.sleep(0.1)
+        if not ok:
+            logger.warning("end_page_print did not ACK — continuing")
+
+        for _ in range(40):
+            status = await self.get_print_status_quick()
+            if status and status.get("page") >= quantity:
+                break
+            await asyncio.sleep(0.15)
+
+        packet = await self.send_command(RequestCodeEnum.END_PRINT, b"\x01", timeout=2)
+        if not packet:
+            logger.warning("end_print did not ACK")
+
+    async def get_print_status_quick(self):
+        packet = await self.send_command(RequestCodeEnum.GET_PRINT_STATUS, b"\x01", timeout=2)
+        if not packet or not packet.data or len(packet.data) < 4:
+            return None
+        page, progress1, progress2 = struct.unpack(">HBB", packet.data[:4])
+        return {"page": page, "progress1": progress1, "progress2": progress2}
+
+    async def print_image_v2(self, image: Image, density: int = 3, quantity: int = 1,
+                            vertical_offset=0, horizontal_offset=0):
+        """B1 protocol (niimbluelib B1PrintTask): 7-byte PrintStart + 6-byte SetPageSize.
+
+        Fixes from PR #6 review (MultiMote / hadess):
+        - total page count in PrintStart must equal quantity (not hardcoded 1)
+        - SetPageSize copies field must match quantity for multi-copy jobs
+        """
+        await self.set_label_density(density)
+        await self.set_label_type(1)
+        await self.start_print_v2(quantity=quantity)
+        await self.start_page_print()
+        await self.set_dimension_v2(image.height, image.width, quantity)
 
         for pkt in self._encode_image(image, vertical_offset, horizontal_offset):
-            # Send each line and wait for a response or status check
             await self.write_raw(pkt)
-            # Adding a short delay or status check here can help manage buffer issues
-            await asyncio.sleep(0.01)  # Adjust the delay as needed based on printer feedback
+            await asyncio.sleep(0.015)
 
-        while not await self.end_page_print():
+        for _ in range(40):
+            try:
+                if await self.end_page_print():
+                    break
+            except Exception as e:
+                logger.debug(f"end_page_print: {e}")
             await asyncio.sleep(0.05)
 
-        while True:
-            status = await self.get_print_status()
-            if status['page'] == quantity:
+        # Give B1 time to finish multi-copy jobs before tearing down BLE.
+        await asyncio.sleep(0.5 + 0.4 * max(0, quantity - 1))
+
+        for _ in range(100):
+            try:
+                status = await self.get_print_status()
+                if status and status.get("page") == quantity:
+                    break
+            except Exception as e:
+                logger.debug(f"get_print_status: {e}")
                 break
             await asyncio.sleep(0.1)
 
-        await self.end_print()
+        try:
+            await self.end_print()
+        except Exception as e:
+            logger.debug(f"end_print: {e}")
 
-    def _encode_image(self, image: Image, vertical_offset=0, horizontal_offset=0):
-        # Convert the image to monochrome
-        img = ImageOps.invert(image.convert("L")).convert("1")
+    # Backwards-compatible alias used by PR #6 / older callers
+    print_imageV2 = print_image_v2
 
-        # Apply horizontal offset
+    async def print_for_model(self, model: str, image: Image, density: int = 3, quantity: int = 1,
+                             vertical_offset=0, horizontal_offset=0):
+        """Dispatch to the correct print protocol for the selected model."""
+        from .models import uses_b1_protocol, uses_page_size_6b
+        if uses_b1_protocol(model):
+            await self.print_image_v2(image, density=density, quantity=quantity,
+                                     vertical_offset=vertical_offset,
+                                     horizontal_offset=horizontal_offset)
+        else:
+            await self.print_image(
+                image,
+                density=density,
+                quantity=quantity,
+                vertical_offset=vertical_offset,
+                horizontal_offset=horizontal_offset,
+                page_size_6b=uses_page_size_6b(model),
+            )
+
+    async def handshake_connect(self):
+        """Send Connect (0xC1) with 0x03 prefix to reset printer print state."""
+        packet = await self.send_command(RequestCodeEnum.CONNECT, b"\x01", timeout=3)
+        return packet is not None
+
+    def _encode_image(self, image: Image, vertical_offset=0, horizontal_offset=0, invert: bool = True):
+        """Encode image rows for PrintBitmapRow (0x85).
+
+        Matches AndBondStyle/niimprint: invert so black→bit1, counts can be zeros.
+        """
+        gray = image.convert("L")
+        if invert:
+            gray = ImageOps.invert(gray)
+        img = gray.convert("1", dither=Image.Dither.NONE)
+
         if horizontal_offset > 0:
             img = ImageOps.expand(img, border=(horizontal_offset, 0, 0, 0), fill=1)
         else:
             img = img.crop((-horizontal_offset, 0, img.width, img.height))
 
-        # Add vertical padding for vertical offset
         img = ImageOps.expand(img, border=(0, vertical_offset, 0, 0), fill=1)
 
+        if img.width % 8 != 0:
+            pad = 8 - (img.width % 8)
+            img = ImageOps.expand(img, border=(0, 0, pad, 0), fill=1)
+
         for y in range(img.height):
-            line_data = [img.getpixel((x, y)) for x in range(img.width)]
-            line_data = "".join("0" if pix == 0 else "1" for pix in line_data)
-            line_data = int(line_data, 2).to_bytes(math.ceil(img.width / 8), "big")
-            counts = (0, 0, 0)  # It seems like you can always send zeros
-            header = struct.pack(">H3BB", y, *counts, 1)
-            pkt = NiimbotPacket(0x85, header + line_data)
-            yield pkt
+            bitstring = "".join("0" if img.getpixel((x, y)) == 0 else "1" for x in range(img.width))
+            payload = int(bitstring, 2).to_bytes(img.width // 8, "big")
+            # Zeros are accepted by B21/B21S firmware (AndBondStyle)
+            header = struct.pack(">H3BB", y, 0, 0, 0, 1)
+            yield NiimbotPacket(0x85, header + payload)
 
     async def get_info(self, key):
         response = await self.send_command(RequestCodeEnum.GET_INFO, bytes((key,)))
@@ -255,45 +388,70 @@ class PrinterClient:
     async def set_label_type(self, n):
         assert 1 <= n <= 3
         packet = await self.send_command(RequestCodeEnum.SET_LABEL_TYPE, bytes((n,)))
-        return bool(packet.data[0])
+        return bool(packet and packet.data and packet.data[0])
 
     async def set_label_density(self, n):
         assert 1 <= n <= 5  # B21 has 5 levels, not sure for D11
         packet = await self.send_command(RequestCodeEnum.SET_LABEL_DENSITY, bytes((n,)))
-        return bool(packet.data[0])
+        return bool(packet and packet.data and packet.data[0])
 
     async def start_print(self):
         packet = await self.send_command(RequestCodeEnum.START_PRINT, b"\x01")
-        return bool(packet.data[0])
+        return bool(packet and packet.data and packet.data[0])
+
+    async def start_print_v2(self, quantity: int):
+        """B1 / newer printers: 7-byte PrintStart (big-endian page count + padding + color).
+
+        Wire format (niimbluelib printStart7b):
+          u16be total_pages | 0x00 0x00 0x00 0x00 | page_color
+        """
+        assert 1 <= quantity <= 65535
+        payload = struct.pack(">H", quantity) + b"\x00\x00\x00\x00\x00"
+        packet = await self.send_command(RequestCodeEnum.START_PRINT, payload)
+        return bool(packet and packet.data and packet.data[0])
+
+    start_printV2 = start_print_v2
 
     async def end_print(self):
         packet = await self.send_command(RequestCodeEnum.END_PRINT, b"\x01")
-        return bool(packet.data[0])
+        return bool(packet and packet.data and packet.data[0])
 
     async def start_page_print(self):
         packet = await self.send_command(RequestCodeEnum.START_PAGE_PRINT, b"\x01")
-        return bool(packet.data[0])
+        return bool(packet and packet.data and packet.data[0])
 
     async def end_page_print(self):
         packet = await self.send_command(RequestCodeEnum.END_PAGE_PRINT, b"\x01")
-        return bool(packet.data[0])
+        return bool(packet and packet.data and packet.data[0])
 
     async def allow_print_clear(self):
         packet = await self.send_command(RequestCodeEnum.ALLOW_PRINT_CLEAR, b"\x01")
-        return bool(packet.data[0])
+        return bool(packet and packet.data and packet.data[0])
 
     async def set_dimension(self, w, h):
         packet = await self.send_command(
             RequestCodeEnum.SET_DIMENSION, struct.pack(">HH", w, h)
         )
-        return bool(packet.data[0])
+        return bool(packet and packet.data and packet.data[0])
+
+    async def set_dimension_v2(self, w, h, copies):
+        """B1: 6-byte SetPageSize (rows, cols, copies) — copies must match quantity."""
+        assert 1 <= copies <= 65535
+        packet = await self.send_command(
+            RequestCodeEnum.SET_DIMENSION, struct.pack(">HHH", w, h, copies)
+        )
+        return bool(packet and packet.data and packet.data[0])
+
+    set_dimensionV2 = set_dimension_v2
 
     async def set_quantity(self, n):
         packet = await self.send_command(RequestCodeEnum.SET_QUANTITY, struct.pack(">H", n))
-        return bool(packet.data[0])
+        return bool(packet and packet.data and packet.data[0])
 
     async def get_print_status(self):
         packet = await self.send_command(RequestCodeEnum.GET_PRINT_STATUS, b"\x01")
+        if not packet or not packet.data or len(packet.data) < 4:
+            return None
         page, progress1, progress2 = struct.unpack(">HBB", packet.data[:4])
         return {"page": page, "progress1": progress1, "progress2": progress2}
 

--- a/NiimPrintX/ui/AppConfig.py
+++ b/NiimPrintX/ui/AppConfig.py
@@ -1,6 +1,12 @@
 import os
 import appdirs
 import platform
+
+
+def _sizes(*pairs):
+    return {f"{w}mm x {h}mm": (w, h) for w, h in pairs}
+
+
 class AppConfig:
     def __init__(self):
         self.os_system = platform.system()
@@ -14,68 +20,60 @@ class AppConfig:
         self.canvas = None
         self.bounding_box = None
         self.device = None
+        # density = default; density_max = slider ceiling (B-family uses 1–5)
         self.label_sizes = {
             "d110": {
-                "size": {
-                    "30mm x 15mm": (30, 15),
-                    "40mm x 12mm": (40, 12),
-                    "50mm x 14mm": (50, 14),
-                    "75mm x 12mm": (75, 12),
-                    "109mm x 12.5mm": (109, 12.5),
-                },
+                "size": _sizes((30, 15), (40, 12), (50, 14), (75, 12), (109, 12.5)),
                 "density": 3,
-                "print_dpi": 203
+                "density_max": 3,
+                "print_dpi": 203,
             },
             "d11": {
-                "size": {
-                    "30mm x 14mm": (30, 14),
-                    "40mm x 12mm": (40, 12),
-                    "50mm x 14mm": (50, 14),
-                    "75mm x 12mm": (75, 12),
-                    "109mm x 12.5mm": (109, 12.5),
-                },
+                "size": _sizes((30, 14), (40, 12), (50, 14), (75, 12), (109, 12.5)),
                 "density": 3,
-                "print_dpi": 203
-
+                "density_max": 3,
+                "print_dpi": 203,
             },
             "d11_h": {
-                "size": {
-                    "30mm x 14mm": (30, 14),
-                    "40mm x 12mm": (40, 12),
-                    "50mm x 14mm": (50, 14),
-                    "75mm x 12mm": (75, 12),
-                    "109mm x 12.5mm": (109, 12.5),
-                },
+                "size": _sizes((30, 14), (40, 12), (50, 14), (75, 12), (109, 12.5)),
                 "density": 3,
-                "print_dpi": 300
+                "density_max": 5,
+                "print_dpi": 300,
             },
             "d101": {
-                "size": {
-                    "30mm x 14mm": (30, 14),
-                    "40mm x 12mm": (40, 12),
-                    "50mm x 14mm": (50, 14),
-                    "75mm x 12mm": (75, 12),
-                    "109mm x 12.5mm": (109, 12.5),
-                },
+                "size": _sizes((30, 14), (40, 12), (50, 14), (75, 12), (109, 12.5)),
                 "density": 3,
-                "print_dpi": 203
-
+                "density_max": 3,
+                "print_dpi": 203,
             },
             "b18": {
-                "size": {
-                    "40mm x 14mm": (40, 14),
-                    "50mm x 14mm": (50, 14),
-                    "120mm x 14mm": (120, 14),
-                },
+                "size": _sizes((40, 14), (50, 14), (120, 14)),
                 "density": 3,
-                "print_dpi": 203
-
-            }
+                "density_max": 5,
+                "print_dpi": 203,
+            },
+            "b1": {
+                "size": _sizes((50, 30), (50, 15), (60, 40), (40, 30), (30, 15), (80, 50)),
+                "density": 3,
+                "density_max": 5,
+                "print_dpi": 203,
+            },
+            "b21": {
+                "size": _sizes((50, 30), (50, 15), (40, 30), (30, 15), (80, 50), (60, 40)),
+                "density": 3,
+                "density_max": 5,
+                "print_dpi": 203,
+            },
+            "b21s": {
+                "size": _sizes((50, 30), (50, 15), (40, 30), (30, 15), (80, 50), (60, 40)),
+                "density": 3,
+                "density_max": 5,
+                "print_dpi": 203,
+            },
         }
         self.current_label_size = None
         self.frames = {}
         self.print_job = False
         self.printer_connected = False
-        self.cache_dir = appdirs.user_cache_dir('NiimPrintX')
-
-
+        self.cache_dir = appdirs.user_cache_dir("NiimPrintX")
+        self.preview_callback = None

--- a/NiimPrintX/ui/main.py
+++ b/NiimPrintX/ui/main.py
@@ -6,13 +6,13 @@ from tkinter import messagebox
 from .AppConfig import AppConfig
 from .widget.TextTab import TextTab
 from .widget.IconTab import IconTab
+from .widget.ImageTab import ImageTab
 from .widget.StatusBar import StatusBar
 from .widget.PrintOption import PrintOption
+from .widget.Preview import ThermalPreview
 
 from NiimPrintX.ui.widget.CanvasSelector import CanvasSelector
 from NiimPrintX.ui.widget.FileMenu import FileMenu
-
-from NiimPrintX.nimmy.printer import PrinterClient
 
 import asyncio
 import threading
@@ -22,42 +22,22 @@ from loguru import logger
 
 logger.disable('NiimPrintX.nimmy')
 
-# import sys
-# import logging
-#
-# logging.basicConfig(level=logging.DEBUG, filename='/Users/dhivah/Documents/Personal/repos/NiimPrintX/logfile.log', filemode='w',
-#                     format='%(name)s - %(levelname)s - %(message)s')
-
-# def handle_exception(exc_type, exc_value, exc_traceback):
-#     if issubclass(exc_type, KeyboardInterrupt):
-#         sys.__exit__(0)
-#     else:
-#         logging.error("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
-#
-# sys.excepthook = handle_exception
-
 from devtools import debug
+
+
 class LabelPrinterApp(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title('NiimPrintX')
-        width=1100
-        height=800
+        width = 1280
+        height = 860
         x = (self.winfo_screenwidth() // 2) - (width // 2)
         y = (self.winfo_screenheight() // 2) - (height // 2)
         self.geometry(f"{width}x{height}+{x}+{y}")
-        self.resizable(width=True, height=True)  # Allow window to be resizable
+        self.resizable(width=True, height=True)
         self.protocol("WM_DELETE_WINDOW", self.on_close)
         self.withdraw()
-
-        # self.async_loop = asyncio.new_event_loop()
-        # threading.Thread(target=self.start_asyncio_loop, daemon=True).start()
-        #
-        # self.app_config = AppConfig()
-        # self.create_widgets()
-        # self.create_menu()
-        # self.printer = None
-        # self.load_resources()
+        self.thermal_preview = None
 
     def load_resources(self):
         self.async_loop = asyncio.new_event_loop()
@@ -74,44 +54,77 @@ class LabelPrinterApp(tk.Tk):
         self.create_widgets()
         self.create_menu()
         self.printer = None
-        self.after(5000, self.show_main_window)
+        self.after(800, self.show_main_window)
 
     def show_main_window(self):
         self.deiconify()
         self.lift()
+        if self.thermal_preview:
+            self.thermal_preview.refresh()
 
     def create_menu(self):
         menu_bar = tk.Menu(self)
         self.config(menu=menu_bar)
         self.file_menu = FileMenu(self, menu_bar, self.app_config)
 
-
     def create_widgets(self):
-        # Top frame to hold the canvas and Notebook
-        self.app_config.frames["top_frame"] = tk.Frame(self)
-        self.app_config.screen_dpi = int(self.app_config.frames["top_frame"].winfo_fpixels('1i'))
+        # Main horizontal split: editor (left) + thermal preview (right)
+        body = tk.Frame(self)
+        body.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
 
+        left = tk.Frame(body)
+        left.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        right = tk.Frame(body, width=380)
+        right.pack(side=tk.RIGHT, fill=tk.Y, padx=8, pady=8)
+        right.pack_propagate(False)
+
+        self.app_config.frames["top_frame"] = tk.Frame(left)
+        self.app_config.screen_dpi = int(self.app_config.frames["top_frame"].winfo_fpixels('1i'))
         self.app_config.frames["top_frame"].pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=10, pady=10)
 
-        self.tab_control = ttk.Notebook(self)
+        self.tab_control = ttk.Notebook(left)
         self.text_tab = TextTab(self.tab_control, self.app_config)
         self.icon_tab = IconTab(self.tab_control, self.app_config)
+        # Share ImageOperation between IconTab and ImageTab via IconTab's instance
+        icon_img_op = self.icon_tab.get_image_operation() if hasattr(self.icon_tab, "get_image_operation") else None
+        self.image_tab = ImageTab(self.tab_control, self.app_config, img_op=icon_img_op)
 
-        self.tab_control.add(self.text_tab.frame, text='Text')
-        self.tab_control.add(self.icon_tab.frame, text='Icon')
+        self.tab_control.add(self.text_tab.frame, text='Text / Emoji')
+        self.tab_control.add(self.icon_tab.frame, text='Icons')
+        self.tab_control.add(self.image_tab.frame, text='Image')
         self.tab_control.pack(expand=1, fill='both', side=tk.TOP)
 
+        self.app_config.frames["bottom_frame"] = tk.Frame(left)
 
-        # Bottom frame with label size and print button
-        self.app_config.frames["bottom_frame"] = tk.Frame(self)
+        img_op = self.image_tab.get_image_operation()
+        self.canvas_selector = CanvasSelector(
+            self.app_config.frames["bottom_frame"],
+            self.app_config,
+            self.text_tab.get_text_operation(),
+            img_op,
+        )
 
-        self.canvas_selector = CanvasSelector(self.app_config.frames["bottom_frame"], self.app_config,
-                                              self.text_tab.get_text_operation(),
-                                              self.icon_tab.get_image_operation())
-
-        self.print_option = PrintOption(self,self.app_config.frames["bottom_frame"], self.app_config)
-
+        self.print_option = PrintOption(self, self.app_config.frames["bottom_frame"], self.app_config)
         self.app_config.frames["bottom_frame"].pack(side=tk.TOP, fill=tk.X, padx=10, pady=10)
+
+        # Live thermal preview on the right
+        self.thermal_preview = ThermalPreview(
+            right,
+            self.app_config,
+            export_fn=self.print_option.export_to_png,
+        )
+        self.thermal_preview.pack(fill=tk.BOTH, expand=True)
+        self.app_config.preview_callback = self.thermal_preview.refresh
+
+        help_text = (
+            "Workflow:\n"
+            "1. Pick device (B21S / B1 / …)\n"
+            "2. Choose label size\n"
+            "3. Add text, emoji, icons or images\n"
+            "4. Preview → Connect → Print"
+        )
+        ttk.Label(right, text=help_text, justify=tk.LEFT).pack(anchor="w", pady=8)
 
         self.app_config.frames["status_frame"] = tk.Frame(self)
         self.status_bar = StatusBar(self.app_config.frames["status_frame"], self.app_config)
@@ -124,6 +137,7 @@ class LabelPrinterApp(tk.Tk):
     def on_close(self):
         if messagebox.askokcancel("Quit", "Do you want to quit?"):
             self.destroy()
+
 
 if __name__ == "__main__":
     try:

--- a/NiimPrintX/ui/widget/CanvasSelector.py
+++ b/NiimPrintX/ui/widget/CanvasSelector.py
@@ -15,7 +15,7 @@ class CanvasSelector:
     def create_widgets(self):
         device_label = tk.Label(self.frame, text="Device")
         device_label.pack(side=tk.LEFT, padx=10)
-        self.selected_device = tk.StringVar(value="D110")
+        self.selected_device = tk.StringVar(value="B21S")
         device_option = ttk.Combobox(self.frame, textvariable=self.selected_device,
                                      values=list(map(lambda x: x.upper(), self.config.label_sizes.keys())),
                                      state="readonly")
@@ -107,6 +107,8 @@ class CanvasSelector:
         )
 
         self.config.canvas.bind("<Button-1>", self.canvas_op.canvas_click_handler)
+        if callable(self.config.preview_callback):
+            self.config.preview_callback()
 
     def mm_to_pixels(self, mm):
         inches = mm / 25.4

--- a/NiimPrintX/ui/widget/ImageTab.py
+++ b/NiimPrintX/ui/widget/ImageTab.py
@@ -1,0 +1,55 @@
+"""Image import tab — load any PNG/JPEG/WebP onto the label canvas."""
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox
+
+from .ImageOperation import ImageOperation
+
+
+class ImageTab:
+    def __init__(self, parent, config, img_op: ImageOperation | None = None):
+        self.parent = parent
+        self.config = config
+        self.frame = ttk.Frame(parent)
+        self.img_op = img_op or ImageOperation(config)
+        self.create_widgets()
+
+    def get_image_operation(self):
+        return self.img_op
+
+    def create_widgets(self):
+        ttk.Label(
+            self.frame,
+            text="Add a custom image (PNG, JPEG, WebP, GIF). Drag to move, use the handle to resize.",
+        ).pack(anchor="w", padx=8, pady=8)
+
+        btn_row = ttk.Frame(self.frame)
+        btn_row.pack(fill="x", padx=8, pady=4)
+
+        ttk.Button(btn_row, text="Browse image…", command=self.browse_image).pack(side=tk.LEFT, padx=4)
+        ttk.Button(btn_row, text="Delete selected", command=self.img_op.delete_image).pack(side=tk.LEFT, padx=4)
+
+        tip = ttk.Label(
+            self.frame,
+            text="Tip: for thermal printers, high-contrast black-on-white images print best.",
+            foreground="#555",
+        )
+        tip.pack(anchor="w", padx=8, pady=4)
+
+    def browse_image(self):
+        if self.config.canvas is None:
+            messagebox.showerror("Error", "Select a device and label size first.")
+            return
+        path = filedialog.askopenfilename(
+            title="Choose image",
+            filetypes=[
+                ("Images", "*.png *.jpg *.jpeg *.webp *.gif *.bmp"),
+                ("All files", "*.*"),
+            ],
+        )
+        if path:
+            try:
+                self.img_op.load_image(path)
+                if callable(getattr(self.config, "preview_callback", None)):
+                    self.config.preview_callback()
+            except Exception as e:
+                messagebox.showerror("Error", f"Could not load image:\n{e}")

--- a/NiimPrintX/ui/widget/Preview.py
+++ b/NiimPrintX/ui/widget/Preview.py
@@ -1,0 +1,84 @@
+"""Emoji picker and live 1-bit thermal preview helpers."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+from PIL import Image, ImageOps, ImageTk
+
+
+COMMON_EMOJIS = [
+    "⭐", "🔥", "✅", "❌", "⚠️", "📦", "🏷️", "🔧", "💡", "🏠",
+    "❤️", "💙", "💚", "💛", "💜", "🖤", "😀", "😎", "🤖", "🐱",
+    "🐶", "🍕", "☕", "🍺", "🎵", "📷", "💻", "📱", "🔋", "🔌",
+    "➡️", "⬅️", "⬆️", "⬇️", "➕", "➖", "✖️", "➗", "①", "②",
+    "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩", "Ⓐ", "Ⓑ",
+]
+
+
+class EmojiPicker(tk.Toplevel):
+    def __init__(self, master, on_pick):
+        super().__init__(master)
+        self.title("Emoji")
+        self.resizable(False, False)
+        self.on_pick = on_pick
+        frame = ttk.Frame(self, padding=8)
+        frame.pack(fill="both", expand=True)
+        cols = 10
+        for i, emoji in enumerate(COMMON_EMOJIS):
+            btn = tk.Button(
+                frame,
+                text=emoji,
+                font=("Noto Color Emoji", 16),
+                width=3,
+                command=lambda e=emoji: self._pick(e),
+            )
+            btn.grid(row=i // cols, column=i % cols, padx=2, pady=2)
+
+    def _pick(self, emoji: str):
+        self.on_pick(emoji)
+        self.destroy()
+
+
+class ThermalPreview(ttk.LabelFrame):
+    """Shows a live 1-bit preview of what will be sent to the printer."""
+
+    def __init__(self, parent, config, export_fn):
+        super().__init__(parent, text="Thermal preview (1-bit)", padding=6)
+        self.config = config
+        self.export_fn = export_fn
+        self._photo = None
+        self.image_label = ttk.Label(self)
+        self.image_label.pack(padx=4, pady=4)
+        btn = ttk.Button(self, text="Refresh preview", command=self.refresh)
+        btn.pack(pady=4)
+        self.hint = ttk.Label(self, text="White paper · black heat", foreground="#666")
+        self.hint.pack()
+
+    def refresh(self):
+        try:
+            if self.config.canvas is None:
+                self.hint.configure(text="Select a label size to preview")
+                return
+            # Force geometry update so export crop matches on-screen label
+            self.config.canvas.update_idletasks()
+            img = self.export_fn(output_filename=None)
+            if img is None:
+                return
+            # Simulate thermal: pure B/W
+            bw = ImageOps.grayscale(img.convert("RGB")).point(
+                lambda p: 0 if p < 180 else 255, mode="L"
+            ).convert("1")
+            # Fit preview into sidebar (~340px) without distorting
+            max_w, max_h = 340, 280
+            scale = min(max_w / max(1, bw.width), max_h / max(1, bw.height), 3)
+            scale = max(1, int(scale)) if scale >= 1 else scale
+            new_size = (max(1, int(bw.width * scale)), max(1, int(bw.height * scale)))
+            preview = bw.convert("L").resize(new_size, Image.Resampling.NEAREST)
+            bordered = ImageOps.expand(preview, border=2, fill=0)
+            self._photo = ImageTk.PhotoImage(bordered)
+            self.image_label.configure(image=self._photo)
+            self.hint.configure(
+                text=f"{bw.width}×{bw.height}px · {(self.config.device or '?').upper()} · print area"
+            )
+        except Exception as e:
+            self.hint.configure(text=f"Preview unavailable: {e}")

--- a/NiimPrintX/ui/widget/PrintOption.py
+++ b/NiimPrintX/ui/widget/PrintOption.py
@@ -114,28 +114,29 @@ class PrintOption:
         return int(inches * self.config.label_sizes[self.config.device]["print_dpi"])
 
     def export_to_png(self, output_filename=None, horizontal_offset=0.0, vertical_offset=0.0):
-        width = self.config.canvas.winfo_reqwidth()
-        height = self.config.canvas.winfo_reqheight()
+        # Use the canvas's real pixel size (reqwidth can be wrong before map → crop offset)
+        width = max(int(self.config.canvas.winfo_width()), int(self.config.canvas.winfo_reqwidth()), 1)
+        height = max(int(self.config.canvas.winfo_height()), int(self.config.canvas.winfo_reqheight()), 1)
 
         horizontal_offset_pixels = self.mm_to_pixels(horizontal_offset)
         vertical_offset_pixels = self.mm_to_pixels(vertical_offset)
 
-        x1, y1, x2, y2 = self.config.canvas.bbox(self.config.bounding_box)
+        # coords() is the true geometry; bbox() expands by the outline and shifts the crop.
+        crop_id = getattr(self.config, "print_area_box", None) or self.config.bounding_box
+        x1, y1, x2, y2 = self.config.canvas.coords(crop_id)
+        x1 = float(x1) + horizontal_offset_pixels
+        y1 = float(y1) + vertical_offset_pixels
+        x2 = float(x2) + horizontal_offset_pixels
+        y2 = float(y2) + vertical_offset_pixels
 
-        x1 += horizontal_offset_pixels
-        y1 += vertical_offset_pixels
-        x2 += horizontal_offset_pixels
-        y2 += vertical_offset_pixels
-
-        bbox_width = x2 - x1
-        bbox_height = y2 - y1
+        bbox_width = max(1, int(round(x2 - x1)))
+        bbox_height = max(1, int(round(y2 - y1)))
 
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
         ctx = cairo.Context(surface)
-        ctx.set_source_rgb(1, 1, 1)  # White background
+        ctx.set_source_rgb(1, 1, 1)
         ctx.paint()
 
-        # Drawing images (if any)
         if self.config.image_items:
             for img_id, img_props in self.config.image_items.items():
                 coords = self.config.canvas.coords(img_id)
@@ -147,7 +148,6 @@ class PrintOption:
                 ctx.set_source_surface(img_surface, coords[0], coords[1])
                 ctx.paint()
 
-        # Drawing text items
         if self.config.text_items:
             for text_id, text_props in self.config.text_items.items():
                 coords = self.config.canvas.coords(text_id)
@@ -159,8 +159,7 @@ class PrintOption:
                 ctx.set_source_surface(img_surface, coords[0], coords[1])
                 ctx.paint()
 
-        # Create a cropped surface to save
-        cropped_surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, int(bbox_width), int(bbox_height))
+        cropped_surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, bbox_width, bbox_height)
         cropped_ctx = cairo.Context(cropped_surface)
         cropped_ctx.set_source_surface(surface, -x1, -y1)
         cropped_ctx.paint()
@@ -168,9 +167,8 @@ class PrintOption:
             cropped_surface.write_to_png(output_filename)
         else:
             image_bytes = cropped_surface.get_data()
-            img = Image.frombuffer("RGBA", (int(bbox_width), int(bbox_height)), image_bytes, "raw", "BGRA", 0, 1)
-
-            return img
+            img = Image.frombuffer("RGBA", (bbox_width, bbox_height), image_bytes, "raw", "BGRA", 0, 1)
+            return img.copy()
 
     def display_image_in_popup(self, filename):
         # Create a new Toplevel window
@@ -190,11 +188,13 @@ class PrintOption:
         option_frame.grid(row=1, column=0, columnspan=4, padx=20, pady=10, sticky="ew")
 
         self.print_density = tk.IntVar()
-        self.print_density.set(3)
+        default_density = self.config.label_sizes[self.config.device]['density']
+        density_max = self.config.label_sizes[self.config.device].get('density_max', default_density)
+        self.print_density.set(default_density)
         tk.Label(option_frame, text="Density").grid(row=0, column=0, padx=5, pady=5, sticky="e")
         density_slider = tk.Spinbox(option_frame,
                                     from_=1,
-                                    to=self.config.label_sizes[self.config.device]['density'],
+                                    to=density_max,
                                     textvariable=self.print_density,
                                     width=4
                                     )
@@ -277,7 +277,12 @@ class PrintOption:
         self.print_button.config(state=tk.DISABLED)
         self.config.print_job = True
 
-        image = image.rotate(-int(90), PIL.Image.NEAREST, expand=True)
+        # D11/D110 family: labels are usually printed with -90° so the long edge feeds.
+        # B21 / B21S / B1 use printDirection "top" — do not rotate (matches niimbluelib).
+        device = (self.config.device or "").lower()
+        if device not in ("b21", "b21s", "b1", "b18"):
+            image = image.rotate(-90, PIL.Image.NEAREST, expand=True)
+
         future = asyncio.run_coroutine_threadsafe(
             self.print_op.print(image, density, quantity), self.root.async_loop
         )

--- a/NiimPrintX/ui/widget/PrinterOperation.py
+++ b/NiimPrintX/ui/widget/PrinterOperation.py
@@ -3,8 +3,6 @@ from tkinter import messagebox
 from NiimPrintX.nimmy.bluetooth import find_device
 from NiimPrintX.nimmy.printer import PrinterClient
 
-from devtools import debug
-
 
 class PrinterOperation:
     def __init__(self, config):
@@ -19,8 +17,7 @@ class PrinterOperation:
                 self.config.printer_connected = True
                 return True
         except Exception as e:
-            # debug(e)
-            messagebox.showerror("Error", f"Cannot connect to printer {model}.")
+            messagebox.showerror("Error", f"Cannot connect to printer {model}.\n{e}")
             return False
 
     async def printer_disconnect(self):
@@ -40,7 +37,12 @@ class PrinterOperation:
             if not self.config.printer_connected or not self.printer:
                 await self.printer_connect(self.config.device)
 
-            await self.printer.print_image(image, density, quantity)
+            await self.printer.print_for_model(
+                self.config.device,
+                image,
+                density=density,
+                quantity=quantity,
+            )
             return True
         except Exception as e:
             messagebox.showerror("Error", f"{str(e)}.")
@@ -51,7 +53,6 @@ class PrinterOperation:
             if self.printer:
                 hb = await self.printer.heartbeat()
                 return True, hb
-        except Exception as e:
-            # print(f"Error {e}")
+        except Exception:
             self.printer = None
             return False, {}

--- a/NiimPrintX/ui/widget/TextOperation.py
+++ b/NiimPrintX/ui/widget/TextOperation.py
@@ -17,8 +17,17 @@ class TextOperation:
     # Function to add text to canvas and make it draggable
     def create_text_image(self, font_props, text):
         with WandDrawing() as draw:
-            # draw.font = font_props["font_name"]
             draw.font_family = font_props["family"]
+            # Prefer an emoji-capable font when the string contains non-BMP / symbol chars
+            if any(ord(ch) > 0x2FFF for ch in text):
+                for family in ("Noto Color Emoji", "Noto Emoji", "Segoe UI Emoji", "Apple Color Emoji"):
+                    try:
+                        draw.font_family = family
+                        break
+                    except Exception:
+                        continue
+                # Keep the chosen text font as primary; ImageMagick falls back for missing glyphs
+                draw.font_family = f"{font_props['family']}, Noto Color Emoji, Noto Emoji, DejaVu Sans"
             draw.font_size = font_props["size"]
             if font_props["slant"] == 'italic':
                 draw.font_style = 'italic'
@@ -27,24 +36,19 @@ class TextOperation:
             if font_props["underline"]:
                 draw.text_decoration = 'underline'
             draw.text_kerning = font_props["kerning"]
-            draw.fill_color = Color('black')  # Set font color to black
-            draw.resolution = (300, 300)  # 300 DPI for high quality text rendering
+            draw.fill_color = Color('black')
+            draw.resolution = (300, 300)
             metrics = draw.get_font_metrics(WandImage(width=1, height=1), text, multiline=True)
-            text_width = int(metrics.text_width) + 5
-            text_height = int(metrics.text_height) + 5
+            text_width = max(int(metrics.text_width) + 5, 8)
+            text_height = max(int(metrics.text_height) + 5, 8)
 
-            # Create a new WandImage
             with WandImage(width=text_width, height=text_height, background=Color('transparent')) as img:
-                # Position text at top using ascender for proper multi-line rendering
-                draw.text(x=2, y=int(metrics.ascender), body=text)
+                draw.text(x=2, y=int(metrics.ascender) if metrics.ascender else font_props["size"], body=text)
                 draw(img)
 
-                # Ensure the image is in RGBA format
                 img.format = 'png'
-                img.alpha_channel = 'activate'  # Ensure alpha channel is active
-                img_blob = img.make_blob('png32')  # Use 'png32' for RGBA
-                # img.save(filename="test.png")
-                # Convert to format displayable in Tkinter
+                img.alpha_channel = 'activate'
+                img_blob = img.make_blob('png32')
                 tk_image = tk.PhotoImage(data=img_blob)
                 return tk_image
     def add_text_to_canvas(self):
@@ -68,6 +72,8 @@ class TextOperation:
             "bbox": None,
 
         }
+        if callable(self.config.preview_callback):
+            self.config.preview_callback()
 
     def delete_text(self):
         if self.config.current_selected:

--- a/NiimPrintX/ui/widget/TextTab.py
+++ b/NiimPrintX/ui/widget/TextTab.py
@@ -95,13 +95,24 @@ class TextTab:
         button_frame = tk.Frame(self.frame)
         self.add_button = tk.Button(button_frame, text="Add", highlightbackground=default_bg,
                                     command=self.text_op.add_text_to_canvas)
-        # add_button.grid(row=3, column=1, rowspan=4, padx=5)
 
         self.delete_button = tk.Button(button_frame, text="Delete", highlightbackground=default_bg,
                                        command=self.text_op.delete_text)
+        self.emoji_button = tk.Button(button_frame, text="Emoji…", highlightbackground=default_bg,
+                                      command=self.open_emoji_picker)
         self.add_button.pack(side=tk.LEFT)
         self.delete_button.pack(side=tk.LEFT)
+        self.emoji_button.pack(side=tk.LEFT)
         button_frame.grid(row=4, column=1, sticky="w")
+
+    def open_emoji_picker(self):
+        from .Preview import EmojiPicker
+
+        def insert_emoji(emoji: str):
+            self.content_entry.insert(tk.INSERT, emoji)
+            self.update_text_properties()
+
+        EmojiPicker(self.frame.winfo_toplevel(), insert_emoji)
 
     def update_font_list(self, event=None):
         font_family = self.font_family_dropdown.get()

--- a/README.md
+++ b/README.md
@@ -8,16 +8,25 @@
 
 ![NiimPrintX](docs/assets/NiimPrintX.gif)
 
-NiimPrintX is a Python library designed to seamlessly interface with NiimBot label printers via Bluetooth. 
+NiimPrintX is a Python library designed to seamlessly interface with NiimBot label printers via Bluetooth.
 It provides both a Command-Line Interface (CLI) and a Graphical User Interface (GUI) for users to design and print labels efficiently.
+
+> **Hardware testing disclaimer:** The B21S protocol fixes and end-to-end print path in this branch were **tested only on a Niimbot B21S**. B1 support is included based on [PR #6](https://github.com/labbots/NiimPrintX/pull/6) (see Credits), but has **not** been hardware-verified here. Other models keep their previous code paths — please validate on your own printer before relying on them.
 
 ## Key Features
 * **Cross-Platform Compatibility:** NiimPrintX works on Windows, macOS, and Linux, ensuring broad usability.
 * **Bluetooth Connectivity:** Effortlessly connect to your NiimBot label printers via Bluetooth.
-* **Comprehensive Model Support:** Compatible with multiple NiimBot printer models (D11, B21, B1, D110, B18).
-* **Dual Interface Options:** Provides both Command-Line Interface (CLI) and Graphical User Interface (GUI) to suit different user preferences.
-* **Custom Label Design:** The GUI app enables users to design labels tailored to specific devices and label sizes.
-* **Advanced Print Settings:** Customize print density, quantity, and image rotation for precise label printing.
+* **Model Support:** D11, D11_H, D110, D101, B18, B21, **B21S**, and **B1** (see testing disclaimer above).
+* **Dual Interface Options:** CLI and GUI for automation or interactive label design.
+* **Custom Label Design:** GUI supports text, emoji, built-in icons, custom images, and a live 1-bit thermal preview.
+* **Advanced Print Settings:** Density, quantity, and image rotation.
+* **Protocol variants:** Model-aware print dispatch (B1 7-byte PrintStart / 6-byte SetPageSize; B21S 6-byte SetPageSize + BLE MTU handling).
+
+## What's new (this contribution)
+* **B21S support:** 6-byte `SetPageSize` (blank labels with 4-byte size), BLE MTU negotiation, reliable GATT writes, Connect handshake, and model name matching that does not confuse `B1` with `B21`/`B21S`.
+* **B1 support:** Merged protocol approach from [PR #6](https://github.com/labbots/NiimPrintX/pull/6) by [@LorisPolenz](https://github.com/LorisPolenz), including MultiMote's review fix so print quantity / page count is passed correctly.
+* **GUI:** Image tab, emoji picker, live thermal preview, B1/B21/B21S label sizes, density max 1–5 for B-family, print-area-accurate export (no outline crop offset).
+* **CLI:** `-m b21s` (and existing `-m b1`) with shared model metadata.
 
 ## Requirements
 To run NiimPrintX, you need to have the following installed:
@@ -25,6 +34,7 @@ To run NiimPrintX, you need to have the following installed:
 * Python 3.12 or later
 * ImageMagick library
 * Poetry for dependency management
+* On Linux: Bluetooth (`bluez`), and for the GUI: `libcairo2-dev`, `pkg-config`, `python3-tk`
 
 
 ## Installation
@@ -43,6 +53,12 @@ Install the necessary dependencies using Poetry:
 ```shell
 python -m venv venv
 poetry install
+```
+
+Linux (Debian/Ubuntu) extras for BLE + GUI:
+
+```shell
+sudo apt-get install -y imagemagick libcairo2-dev pkg-config python3-tk bluez
 ```
 
 ### Note:
@@ -81,7 +97,7 @@ Commands:
 Usage: python -m NiimPrintX.cli print [OPTIONS]
 
 Options:
-  -m, --model [b1|b18|b21|d11|d11_h|d110]
+  -m, --model [b1|b18|b21|b21s|d11|d11_h|d110|d101]
                                   Niimbot printer model  [default: d110]
   -d, --density INTEGER RANGE     Print density  [default: 3; 1<=x<=5]
   -n, --quantity INTEGER          Print quantity  [default: 1]
@@ -94,6 +110,12 @@ Options:
 **Example:**
 
 ```shell
+# B21S (50×30 mm @ ~203 dpi → typically 384×240 px, no rotate)
+python -m NiimPrintX.cli print -m b21s -d 5 -n 1 -i path/to/image.png
+
+# B1 (protocol from PR #6 — not hardware-tested in this contribution)
+python -m NiimPrintX.cli print -m b1 -d 3 -n 2 -i path/to/image.png
+
 python -m NiimPrintX.cli print -m d110 -d 3 -n 1 -r 90 -i path/to/image.png
 ```
 
@@ -103,7 +125,7 @@ python -m NiimPrintX.cli print -m d110 -d 3 -n 1 -r 90 -i path/to/image.png
 Usage: python -m NiimPrintX.cli info [OPTIONS]
 
 Options:
-  -m, --model [b1|b18|b21|d11|d110]
+  -m, --model [b1|b18|b21|b21s|d11|d11_h|d110|d101]
                                   Niimbot printer model  [default: d110]
   -h, --help                      Show this message and exit.
 ```
@@ -111,20 +133,28 @@ Options:
 **Example:**
 
 ```shell
-python -m NiimPrintX.cli info -m d110
+python -m NiimPrintX.cli info -m b21s
 ```
 
 ### Graphical User Interface (GUI)
-The GUI application allows users to design labels based on the label device and label size. Simply run the GUI application:
+Design labels with text, emoji, icons, and images; preview a 1-bit thermal render; then print:
 
 ```shell
-python -m NiimPrintX.ui
+poetry run python -m NiimPrintX.ui
 ```
+
+1. Select device (e.g. **B21S**) and label size  
+2. Add content from the Text / Emoji, Icons, or Image tabs  
+3. Use **Thermal preview** to check alignment  
+4. Connect → Print  
 
 ## Contributing
 Contributions are welcome! Please fork the repository and submit a pull request with your improvements.
 
 ## Credits
+* **B1 printer protocol:** Adapted from [PR #6 — Implement Support for B1 Printer](https://github.com/labbots/NiimPrintX/pull/6) by [@LorisPolenz](https://github.com/LorisPolenz), with review feedback from [@MultiMote](https://github.com/MultiMote) (page-count / quantity in PrintStart) and testing notes from [@hadess](https://github.com/hadess).
+* **B21S blank-label / 6-byte SetPageSize insight:** Community findings in [AndBondStyle/niimprint#33](https://github.com/AndBondStyle/niimprint/issues/33) and related discussion in [#17](https://github.com/AndBondStyle/niimprint/issues/17).
+* **Protocol reference:** [niimbluelib](https://github.com/MultiMote/niimbluelib) / [NiimBlue](https://github.com/MultiMote/niimblue) by [@MultiMote](https://github.com/MultiMote).
 * Icons made by [Dave Gandy](https://www.flaticon.com/authors/dave-gandy) from [www.flaticon.com](https://www.flaticon.com/)
 * Icons made by [Pixel perfect](https://www.flaticon.com/authors/pixel-perfect) from [www.flaticon.com](https://www.flaticon.com/)
 * Icons made by [Freepik](https://www.freepik.com) from [www.flaticon.com](https://www.flaticon.com/)


### PR DESCRIPTION
## Summary
- **B21S printing:** 6-byte `SetPageSize` (fixes blank labels with 4-byte size), BLE MTU negotiation, Connect handshake, safer GATT writes, and model matching that no longer confuses `B1` with `B21`/`B21S`.
- **B1 protocol:** Includes the B1 print path from [#6](https://github.com/labbots/NiimPrintX/pull/6) by [@LorisPolenz](https://github.com/LorisPolenz), with [@MultiMote](https://github.com/MultiMote)’s review fix so PrintStart / SetPageSize quantity matches copy count.
- **GUI:** Image tab, emoji picker, live 1-bit thermal preview, B1/B21/B21S sizes, print-area-accurate export (no outline crop offset), model-aware rotation.

**Disclaimer:** End-to-end print testing in this PR was done **only on a Niimbot B21S**. B1 is included from PR #6 but was **not** hardware-verified here. Other models keep prior paths — please validate on your device.

## Credits
- B1 support: [@LorisPolenz](https://github.com/LorisPolenz) via [#6](https://github.com/labbots/NiimPrintX/pull/6); review notes from [@MultiMote](https://github.com/MultiMote) and [@hadess](https://github.com/hadess)
- B21S 6-byte page size insight: [AndBondStyle/niimprint#33](https://github.com/AndBondStyle/niimprint/issues/33)
- Protocol reference: [niimbluelib](https://github.com/MultiMote/niimbluelib) / NiimBlue

## Test plan
- [ ] `poetry install` on Linux with ImageMagick + cairo + bluez
- [x] `python -m NiimPrintX.cli info -m b21s` connects and returns serial/version
- [x] `python -m NiimPrintX.cli print -m b21s -d 5 -n 1 -i <384x240.png>` prints non-blank label
- [x] Multi-copy (`-n 2`) completes without hang
- [ ] GUI: design text/emoji/image on B21S 50×30, preview aligns with print area, Connect → Print
- [ ] B1 owners: smoke-test `-m b1` (untested in this PR)
- [ ] Regression: D110/D11 print still works for those who have hardware


Made with [Cursor](https://cursor.com)